### PR TITLE
Fixing Mac OS X support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,12 +16,15 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      - uses: actions/checkout@v2
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@1.0.0
-      - name: Run ShellSpec
-        run: |
-          curl -fsSL https://git.io/shellspec | sh &&
-          shellspec
+        with:
+          scandir: './bin'
+      - name: Install ShellSpec
+        run: curl -fsSL https://github.com/shellspec/shellspec/releases/latest/download/shellspec-dist.tar.gz | tar -xz -C ..
+      - name: Run Shellspec
+        run: bash ../shellspec/shellspec
       - name: Test asdf-vm plugin
         uses: asdf-vm/actions/plugin-test@v1.0.1
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,6 +18,10 @@ jobs:
     steps:
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@1.0.0
+      - name: Run ShellSpec
+        run: |
+          curl -fsSL https://git.io/shellspec | sh &&
+          shellspec
       - name: Test asdf-vm plugin
         uses: asdf-vm/actions/plugin-test@v1.0.1
         with:

--- a/.shellspec
+++ b/.shellspec
@@ -1,0 +1,12 @@
+--require spec_helper
+
+## Default kcov (coverage) options
+# --kcov-options "--include-path=. --path-strip-level=1"
+# --kcov-options "--include-pattern=.sh"
+# --kcov-options "--exclude-pattern=/.shellspec,/spec/,/coverage/,/report/"
+
+## Example: Include script "myprog" with no extension
+# --kcov-options "--include-pattern=.sh,myprog"
+
+## Example: Only specified files/directories
+# --kcov-options "--include-pattern=myprog,/lib/"

--- a/bin/install
+++ b/bin/install
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-ASDF_INSTALL_TYPE=${ASDF_INSTALL_TYPE:-version  }
+ASDF_INSTALL_TYPE=${ASDF_INSTALL_TYPE:-version}
 TMPDIR=${TMPDIR:-/tmp}
 [ -n "$ASDF_INSTALL_VERSION" ] || (>&2 echo 'Missing ASDF_INSTALL_VERSION' && exit 1)
 [ -n "$ASDF_INSTALL_PATH" ] || (>&2 echo 'Missing ASDF_INSTALL_PATH' && exit 1)
@@ -53,5 +53,7 @@ get_download_url() {
 
 	echo "https://github.com/anchore/grype/releases/download/v${version}/grype_${version}_${platform}_amd64.${suffix}"
 }
+
+${__SOURCED__:+return}
 
 install_grype "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/bin/install
+++ b/bin/install
@@ -22,8 +22,17 @@ install_grype() {
 
 	mkdir -p "${bin_install_path}"
 	echo "Downloading and extracting grype from ${download_url}"
-	curl -sS -L "$download_url" | tar -xz -C "$tmp_path"
-  mv "$tmp_path/grype" "$bin_path"
+
+	if [ "x$(get_arch)" == "xlinux" ]; then
+		curl -sS -L "$download_url" | tar -xz -C "$tmp_path"
+  	mv "$tmp_path/grype" "$bin_path"
+
+	elif [ "x$(get_arch)" == "xdarwin" ]; then
+		curl -sS -L "$download_url" -o "$tmp_path/grype.zip"
+		unzip "$tmp_path/grype.zip" -d "$tmp_path"
+		mv "$tmp_path/grype" "$bin_path"
+	fi
+
 	chmod +x "$bin_path"
 }
 
@@ -33,10 +42,16 @@ get_arch() {
 
 get_download_url() {
 	local version="$1"
+	local suffix
 	local platform
   platform="$(get_arch)"
+	suffix="tar.gz"
 
-	echo "https://github.com/anchore/grype/releases/download/v${version}/grype_${version}_${platform}_amd64.tar.gz"
+	if [ "x${platform}" == "xdarwin" ]; then
+		suffix="zip"
+	fi
+
+	echo "https://github.com/anchore/grype/releases/download/v${version}/grype_${version}_${platform}_amd64.${suffix}"
 }
 
 install_grype "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/spec/install_spec.sh
+++ b/spec/install_spec.sh
@@ -1,0 +1,41 @@
+% ASDF_INSTALL_VERSION: "0.3.0"
+% ASDF_INSTALL_PATH: "$(mktemp)"
+
+Describe "Grype Installation"
+  Include "bin/install"
+
+  Describe "get_download_url()"
+    It "creates a Tarball URL on Linux"
+      Mock uname
+        echo "Linux"
+      End
+      When call get_download_url "$ASDF_INSTALL_VERSION"
+      The output should eq "https://github.com/anchore/grype/releases/download/v0.3.0/grype_0.3.0_linux_amd64.tar.gz"
+    End
+    It "creates a ZIP file URL on Mac OS X"
+      Mock uname
+        echo "Darwin"
+      End
+      When call get_download_url "$ASDF_INSTALL_VERSION"
+      The output should eq "https://github.com/anchore/grype/releases/download/v0.3.0/grype_0.3.0_darwin_amd64.zip"
+    End
+  End
+
+
+  Describe "get_arch()"
+    It "prints the OS on Linux lowercase"
+      Mock uname
+        echo "Linux"
+      End
+      When call get_arch
+      The output should eq "linux"
+    End
+    It "prints the OS on Mac OS X lowercase"
+      Mock uname
+        echo "Darwin"
+      End
+      When call get_arch
+      The output should eq "darwin"
+    End
+  End
+End

--- a/spec/spec_helper.sh
+++ b/spec/spec_helper.sh
@@ -1,0 +1,7 @@
+#shellcheck shell=sh
+
+# set -eu
+
+# shellspec_spec_helper_configure() {
+#   shellspec_import 'support/custom_matcher'
+# }


### PR DESCRIPTION
Since 0.3.0 of grype, they support downloading and installing via ZIP file on Mac OS X (tarball was canceled).

This enhances version allows to install for both Linux and Mac OS platforms.